### PR TITLE
Fix textbox width on mobile

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -98,7 +98,7 @@
 
 <div id="error" style="color:#ff0000"></div>
     <form id="form" autocorrect="off" autocapitalize="none"
-          autocomplete="off" style="width: 50%">
+          autocomplete="off" style="display: flex; max-width: 330px;">
     <br/>
     <div id="guess-wrapper">
     <input placeholder="ניחוש" autocorrect="off" autocapitalize="none"


### PR DESCRIPTION
Fixes #12.

# Before
![before](https://user-images.githubusercontent.com/1915716/157907044-edf71702-bd7b-46a9-a176-de04a12e478d.png)

# After
![after](https://user-images.githubusercontent.com/1915716/157907049-b94c1b39-c402-46da-bc8d-2a4d037eb23c.png)

# Desktop - remains narrow
![image](https://user-images.githubusercontent.com/1915716/157907034-0b60010f-629c-496a-914b-5ae449a275b1.png)
